### PR TITLE
Update shipping discounts copy to preferred method

### DIFF
--- a/source/integrations/sales-tax-calculations.md
+++ b/source/integrations/sales-tax-calculations.md
@@ -125,13 +125,15 @@ At this time we only provide a `shipping` param to cover freight tax. If you nee
   "shipping": 1.5,
   "line_items": [
     {
-      "description": "handling",
+      "description": "Handling Fee",
       "quantity": 1,
       "unit_price": 0.5
     }
   ]
 }
 ```
+
+Shipping discounts should be deducted from the `shipping` param. For free shipping, pass $0 in the `shipping` param.
 
 [Shipping taxability](https://blog.taxjar.com/sales-tax-and-shipping/) is automatically determined by state / region in SmartCalcs. If you need to override this functionality to always collect freight tax, consider using a separate line item for shipping and passing $0 in the `shipping` param.
 

--- a/source/integrations/sales-tax-calculations.md
+++ b/source/integrations/sales-tax-calculations.md
@@ -122,7 +122,14 @@ At this time we only provide a `shipping` param to cover freight tax. If you nee
 
 ```json
 {
-  "shipping": 1.5
+  "shipping": 1.5,
+  "line_items": [
+    {
+      "description": "handling",
+      "quantity": 1,
+      "unit_price": 0.5
+    }
+  ]
 }
 ```
 

--- a/source/integrations/sales-tax-reporting.md
+++ b/source/integrations/sales-tax-reporting.md
@@ -110,16 +110,11 @@ Remember, discounts are provided at the line item level factoring in the quantit
 
 ### Shipping Discounts
 
-SmartCalcs doesn’t provide an order-level discount param for shipping. To handle shipping discounts, use a separate line item. At a minimum, you only need to provide the `discount` parameter. You may want to consider providing a `description` as well.
+SmartCalcs doesn’t provide an order-level discount param for shipping. To handle a shipping discount, simply deduct the amount from the `shipping` param. Given a free shipping discount, set `shipping` to zero.
 
 ```json
 {
-  "line_items": [
-    {
-      "description": "Shipping Discount",
-      "discount": 5
-    }
-  ]
+  "shipping": 0
 }
 ```
 


### PR DESCRIPTION
Rather than recommending shipping discounts be added as a separate line item, this change recommends they be deducted directly from the `shipping` param.

This is the preferred usage of our API because tax calculations are more accurate for jurisdictions that tax (or don't tax) shipping.