### PR TITLE
Explain how order-level discounts should be handled

### DIFF
--- a/source/integrations/sales-tax-calculations.md
+++ b/source/integrations/sales-tax-calculations.md
@@ -192,10 +192,23 @@ Pay special attention to the `discount` param. Pass the **total** discount of th
 <pre>
 Unit Price: $5.00
 Quantity: 3
-Discount: 20%
+Discount: $1.00 each
 </pre>
 
 The `discount` param would be **$3.00**, not $1.00.
+
+```json
+{
+  "line_items": [
+    {
+      "id": "1",
+      "quantity": 3,
+      "unit_price": 5,
+      "discount": 3
+    }
+  ]
+}
+```
 
 ---
 

--- a/source/integrations/sales-tax-calculations.md
+++ b/source/integrations/sales-tax-calculations.md
@@ -210,6 +210,70 @@ The `discount` param would be **$3.00**, not $1.00.
 }
 ```
 
+For order-level discounts, distribute the total discount across line items. Try to match the way your platform handles this. For example:
+
+<pre>
+Discount: 20%
+</pre>
+
+One way is to distribute the discount across line items evenly.
+
+```json
+{
+  "line_items": [
+    {
+      "id": "1",
+      "quantity": 3,
+      "unit_price": 5,
+      "discount": 2
+    },
+    {
+      "id": "2",
+      "quantity": 1,
+      "unit_price": 10,
+      "discount": 2
+    },
+    {
+      "id": "3",
+      "quantity": 1,
+      "unit_price": 5,
+      "discount": 2
+    }
+  ]
+}
+```
+
+Another way is to distribute the discount across line items proportionally.
+
+```json
+{
+  "line_items": [
+    {
+      "id": "1",
+      "quantity": 3,
+      "unit_price": 5,
+      "discount": 3
+    },
+    {
+      "id": "2",
+      "quantity": 1,
+      "unit_price": 10,
+      "discount": 2
+    },
+    {
+      "id": "3",
+      "quantity": 1,
+      "unit_price": 5,
+      "discount": 1
+    }
+  ]
+}
+```
+
+If the platform does not distribute order-level discounts across line items, or if you're not sure, apply either method consistently.
+
+For example, some platforms might add the total discount as a separate line item rather than distributing it. In this case, distribute the discount proportionally or evenly in requests to the SmartCalcs API.
+
 ---
 
 ## Tax Status

--- a/source/integrations/sales-tax-reporting.md
+++ b/source/integrations/sales-tax-reporting.md
@@ -112,6 +112,31 @@ Discount: $1.00 each
 }
 ```
 
+Similar to [sales tax calculations](/integrations/sales-tax-calculations/), remember to distribute order-level discounts across line items proportionally or evenly.
+
+<pre>
+Discount: 50%
+</pre>
+
+```json
+{
+  "line_items": [
+    {
+      "id": "1",
+      "quantity": 2,
+      "unit_price": 5,
+      "discount": 5
+    },
+    {
+      "id": "2",
+      "quantity": 1,
+      "unit_price": 10,
+      "discount": 5
+    }
+  ]
+}
+```
+
 ### Shipping Discounts
 
 SmartCalcs doesn’t provide an order-level discount param for shipping. To handle shipping discounts, use a separate line item. At a minimum, you only need to provide the `discount` parameter. You may want to consider providing a `description` as well.

--- a/source/integrations/sales-tax-reporting.md
+++ b/source/integrations/sales-tax-reporting.md
@@ -93,15 +93,19 @@ The first line item you send in an API request will always be used for the trans
 
 Remember, discounts are provided at the line item level factoring in the quantity, **not per unit.**
 
+<pre>
+Discount: $1.00 each
+</pre>
+
 ```json
 {
   "line_items": [
     {
-      "quantity": 1,
+      "quantity": 3,
       "product_identifier": "12-34234-9",
       "description": "Fuzzy Widget",
-      "unit_price": 15,
-      "discount": 1,
+      "unit_price": 5,
+      "discount": 3,
       "sales_tax": 0.95
     }
   ]


### PR DESCRIPTION
This update adds clarification around how integrations should distribute order-level discounts across line items.

The approach we're recommending is to spread the discount either proportionally or evenly, depending on how the platform already handles this. If the platform does not distribute order-level discounts, choose either method (see "Files changed" for examples of both methods). 