### PR TITLE
Improve Table of Contents

### DIFF
--- a/source/javascripts/components/toc.js
+++ b/source/javascripts/components/toc.js
@@ -23,9 +23,7 @@
 
     if ($(this).prop('tagName') === 'H3') {
       var subheading = tocList.find('> li').last();
-      subheading.prev().prop('tagName') !== 'UL' && tocList.append(
-        '<ul type="none" style="margin-left: -2.5rem"></ul>'
-      );
+      subheading.prev().prop('tagName') !== 'UL' && tocList.append('<ul type="none"></ul>');
       toc.find('ul').last().append(subheading);
     }
   });

--- a/source/javascripts/components/toc.js
+++ b/source/javascripts/components/toc.js
@@ -4,7 +4,8 @@
   }
 
   var toc = $('.docs-toc');
-  var tocHeadlines = $('h2').not(':contains("Guidelines")');
+  var tocList = toc.find('> ol').first();
+  var tocHeadlines = $('h2, h3').not(':contains("Guidelines")');
   var tocGuidelines = $('h2').filter(':contains("Guidelines")');
   var prependText = 'section';
 
@@ -15,14 +16,22 @@
     $(this).attr('id', prependText + '-' + id);
 
     if (header.indexOf('Guidelines') === -1) {
-      toc.find('> ol').first().append('<li><a href="#' + prependText + '-' + id + '">' + header + '</a></li>');
+      tocList.append('<li><a href="#' + prependText + '-' + id + '">' + header + '</a></li>');
     } else {
       toc.find('> ol').last().append('<li><a href="#' + prependText + '-' + id + '">' + header + '</a></li>');
+    }
+
+    if ($(this).prop('tagName') === 'H3') {
+      var subheading = tocList.find('> li').last();
+      subheading.prev().prop('tagName') !== 'UL' && tocList.append(
+        '<ul type="none" style="margin-left: -2.5rem"></ul>'
+      );
+      toc.find('ul').last().append(subheading);
     }
   });
 
   if (!tocGuidelines.length) {
-    toc.find('> ol').first().nextAll().remove();
+    tocList.nextAll().remove();
   }
 
   ScrollSpy.prototype.isInView = function (el) {

--- a/source/javascripts/components/toc.js
+++ b/source/javascripts/components/toc.js
@@ -10,7 +10,7 @@
 
   $.merge(tocHeadlines, tocGuidelines).each(function() {
     var header = $(this).text();
-    var id = header.replace(/\s/g, '-').replace(/[?]/g, '').toLowerCase();
+    var id = header.replace(/\s/g, '-').replace(/[?]/g, '').replace(/&/g, 'and').toLowerCase();
 
     $(this).attr('id', prependText + '-' + id);
 

--- a/source/javascripts/components/toc.js
+++ b/source/javascripts/components/toc.js
@@ -10,7 +10,7 @@
 
   $.merge(tocHeadlines, tocGuidelines).each(function() {
     var header = $(this).text();
-    var id = header.replace(/\s/g, '-').replace(/[?]/g, '').replace(/&/g, 'and').toLowerCase();
+    var id = header.replace(/\s/g, '-').replace(/[?,]/g, '').replace(/&/g, 'and').toLowerCase();
 
     $(this).attr('id', prependText + '-' + id);
 

--- a/source/stylesheets/pages/_docs.scss
+++ b/source/stylesheets/pages/_docs.scss
@@ -158,6 +158,10 @@ body.integrations {
         margin: 10px 0 0 10px;
       }
     }
+
+    ul {
+      margin-left: -2.5rem;
+    }
   }
 
   .docs-title {


### PR DESCRIPTION
This PR adds subheadings (`<h3>` tags) to the Table of Contents:

<img width="193" alt="Screen Shot 2019-07-22 at 9 57 17 AM" src="https://user-images.githubusercontent.com/26824724/61649901-44f49780-ac67-11e9-9ffb-c81299e5c4f8.png">

This is mainly so we have additional sections to link to elsewhere in the documentation, as well as to improve navigation around the developer site.

Also, clicks on Table of Contents links that include an ampersand (e.g., Sales Tax Reporting & Filing) were erroring. This fix simply replaces `&` with `and` in links, which now work correctly.

Headers with commas in them also had issues being linked to. Now, we remove commas in anchor links.