### PR TITLE
Show search results for method names (e.g., `show_order`)

### DIFF
--- a/docsearch.json
+++ b/docsearch.json
@@ -36,6 +36,104 @@
       [
         "go",
         "golang"
+      ],
+      [
+        "tax for order",
+        "taxForOrder",
+        "tax_for_order"
+      ],
+      [
+        "GET List order transactions",
+        "listOrders",
+        "list_orders"
+      ],
+      [
+        "GET Show an order transaction",
+        "showOrder",
+        "show_order"
+      ],
+      [
+        "POST Create an order transaction",
+        "createOrder",
+        "create_order"
+      ],
+      [
+        "PUT Update an order transaction",
+        "updateOrder",
+        "update_order"
+      ],
+      [
+        "DELETE Delete an order transaction",
+        "deleteOrder",
+        "delete_order"
+      ],
+      [
+        "GET List refund transactions",
+        "listRefunds",
+        "list_refunds"
+      ],
+      [
+        "GET Show a refund transaction",
+        "showRefund",
+        "show_refund"
+      ],
+      [
+        "POST Create a refund transaction",
+        "createRefund",
+        "create_refund"
+      ],
+      [
+        "PUT Update a refund transaction",
+        "updateRefund",
+        "update_refund"
+      ],
+      [
+        "DELETE Delete a refund transaction",
+        "deleteRefund",
+        "delete_refund"
+      ],
+      [
+        "GET List customers",
+        "listCustomers",
+        "list_customers"
+      ],
+      [
+        "GET Show a customer",
+        "showCustomer",
+        "show_customer"
+      ],
+      [
+        "POST Create a customer",
+        "createCustomer",
+        "create_customer"
+      ],
+      [
+        "PUT update a customer",
+        "updateCustomer",
+        "update_customer"
+      ],
+      [
+        "DELETE Delete a customer",
+        "deleteCustomer",
+        "delete_customer"
+      ],
+      [
+        "GET Show tax rates for a location",
+        "ratesForLocation",
+        "rates_for_location"
+      ],
+      [
+        "GET List nexus regions",
+        "nexus_regions"
+      ],
+      [
+        "Validate an address",
+        "validateAddress",
+        "validate_address"
+      ],
+      [
+        "summary_rates",
+        "summaryRates"
       ]
     ]
   }


### PR DESCRIPTION
## Problem

Each week, Algolia shares with us a digest of our search activity on [developers.taxjar.com](https://developers.taxjar.com), including searches with no results.

<img width="599" alt="Screen Shot 2019-12-09 at 5 28 36 AM" src="https://user-images.githubusercontent.com/26824724/70439450-e6c52700-1a44-11ea-98ce-9e1ac67012a0.png">

A recurring theme for the past few weeks is that _some_ snake_case method names for Ruby/Python have no search result. These _would_ have shown up due to hits in the sidebar:

<img width="606" alt="Screen Shot 2019-12-09 at 5 32 34 AM" src="https://user-images.githubusercontent.com/26824724/70439823-b0d47280-1a45-11ea-8970-a6010c80cf82.png">

However, in order to limit duplicate search results we had to exclude the sidebar as a whole.

## Solution

This PR adds synonyms to the `docsearch.json` config so that all method names (no matter the casing) now have search results. For example:

<img width="511" alt="Screen Shot 2019-12-09 at 5 50 53 AM" src="https://user-images.githubusercontent.com/26824724/70440829-e712f180-1a47-11ea-96e2-7f024e34ed00.png">
