### PR TITLE
Minor improvements to Certification Checklist

### DIFF
--- a/source/integrations/certification-checklist.md
+++ b/source/integrations/certification-checklist.md
@@ -105,9 +105,9 @@ When building a TaxJar integration, use this checklist as a guide to what we loo
 
 Pass the following required params for transactions:
 
-<label><input type="checkbox">&nbsp;&nbsp; Unique `id` for each [order](/integrations/sales-tax-reporting/#section-order-transactions) and [refund](/integrations/sales-tax-reporting/#section-refund-transactions)</label>
+<label><input type="checkbox">&nbsp;&nbsp; Unique `transaction_id` for each [order](/integrations/sales-tax-reporting/#section-order-transactions) and [refund](/integrations/sales-tax-reporting/#section-refund-transactions)</label>
 
-<label><input type="checkbox">&nbsp;&nbsp; [Transaction reference ID](/integrations/sales-tax-reporting/#section-refund-transactions) for refunds</label>
+<label><input type="checkbox">&nbsp;&nbsp; `transaction_reference_id` [for refunds](/integrations/sales-tax-reporting/#section-refund-transactions)</label>
 
 <label><input type="checkbox">&nbsp;&nbsp; `transaction_date` for each transaction</label>
 
@@ -136,7 +136,7 @@ Pass the following required params for transactions:
 
   - <label><input type="checkbox">&nbsp;&nbsp; Line item `discount`</label>
 
-<label><input type="checkbox">&nbsp;&nbsp; <small style="color: grey">optional</small>&nbsp; [Include **customer_id** for exempt customers](/integrations/sales-tax-calculations/#section-customer-exemptions)</label>
+<label><input type="checkbox">&nbsp;&nbsp; <small style="color: grey">optional</small>&nbsp; [Pass **customer_id**](/integrations/sales-tax-calculations/#section-customer-exemptions)&nbsp;<small>(required if supporting customer exemptions)</small></label>
 
 <label><input type="checkbox">&nbsp;&nbsp; [Distribute order-level discounts across line items](/integrations/sales-tax-reporting/#section-line-items)</label>
 


### PR DESCRIPTION
The main motivation for this PR was to correct `id` to `transaction_id`:

<img width="420" alt="Screen Shot 2019-11-26 at 7 44 49 PM" src="https://user-images.githubusercontent.com/26824724/70490032-3130bd00-1ab2-11ea-9fb0-87cd66453a9d.png">

Also, went through the rest of the checklist and made a couple more tweaks.