### PR TITLE
Explain proper handling of gift cards

### DIFF
--- a/source/integrations/certification-checklist.md
+++ b/source/integrations/certification-checklist.md
@@ -142,6 +142,12 @@ Pass the following required params for transactions:
 
 <label><input type="checkbox">&nbsp;&nbsp; [Deduct shipping discounts from the **shipping** param](/integrations/sales-tax-reporting/#section-shipping-discounts)</label>
 
+<label><input type="checkbox">&nbsp;&nbsp; <small style="color: grey">optional</small>&nbsp; Do **not** include gift cards or store credit in the `discount` param</label>
+
+<ul style="list-style-type: none; margin-left: -1.5rem">
+  <li><small>Gift cards are tax-exempt when purchased, but do not reduce tax when applied to an order.</small></li>
+</ul>
+
 <label><input type="checkbox">&nbsp;&nbsp; Use positive decimals in monetary values for order transactions</label>
 
 <label><input type="checkbox">&nbsp;&nbsp; Use negative decimals in monetary values for refund transactions</label>

--- a/source/integrations/sales-tax-reporting.md
+++ b/source/integrations/sales-tax-reporting.md
@@ -139,6 +139,8 @@ Discount: 50%
 }
 ```
 
+**Note:** If an order is paid for with a gift card or store credit, the amount should **not** be included in `discount`. Gift cards are tax-exempt when purchased, but do not reduce tax when applied to an order.
+
 ### Customer Exemptions
 
 When exempting orders from sales tax for a given customer, your merchants will expect TaxJar to recognize the order as exempt for reporting and filing as well. To support customer exemptions, use our [customer endpoints](https://developers.taxjar.com/api/reference/#customers) to sync a merchant's customers when they're created or updated. After creating a customer in TaxJar with a designated exemption type such as `wholesale` or `government`, you can pass a `customer_id` to our tax calculation and transaction endpoints. This allows us to determine whether or not the customer should be exempt from sales tax.


### PR DESCRIPTION
To improve the accuracy of transactions, this PR explains that gift cards or store credit used to pay for an order should **not** be included in the `discount` param.

This update also adds the requirement to the Certification Checklist.