### PR TITLE
Fix .docs-sidebar overflow issue

### DIFF
--- a/source/javascripts/components/docsearch.js
+++ b/source/javascripts/components/docsearch.js
@@ -1,0 +1,40 @@
+(function() {
+'use strict';
+
+  // handle .tocify-wrapper overflow issue:
+  // when docsearch dropdown is shown, overflow should be visible
+  // when docsearch dropdown is hidden, overflow should be auto/hidden
+
+  function resetOverflow() {
+    $('.docs-sidebar').css({
+      'overflow-y': 'auto',
+      'overflow-x': 'hidden'
+    });
+  }
+
+  function createSearchInputs(/* ...selectors */) {
+    $.each(arguments, function(_, selector) {
+      docsearch({
+        appId: '7ZBSP80X0K',
+        apiKey: '2a9d77b7d7b611725a62fd9ffb522880',
+        indexName: 'developers.taxjar.com',
+        inputSelector: selector
+      })
+        .autocomplete.on('autocomplete:shown', function() {
+          $('.docs-sidebar').css({
+            'overflow-y': 'visible',
+            'overflow-x': 'visible'
+          });
+        })
+        .on('autocomplete:closed', resetOverflow);
+
+      $(selector).on('keyup', function(e) {
+        if (e.keyCode === 27 || $(this).val() === '') {
+          resetOverflow();
+        }
+      });
+    });
+  }
+
+  createSearchInputs('#docsearch', '#docsearch-mobile');
+})();

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -65,6 +65,7 @@
         <%= partial "partials/sidebar" %>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
     <%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js" %>
     <%= javascript_include_tag "all" %>
     <%= yield_content :js %>
@@ -76,21 +77,6 @@
 
       ga('create', 'UA-32676850-1', 'auto');
       ga('send', 'pageview');
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-    <script>
-      docsearch({
-        appId: '7ZBSP80X0K',
-        apiKey: '2a9d77b7d7b611725a62fd9ffb522880',
-        indexName: 'developers.taxjar.com',
-        inputSelector: '#docsearch'
-      });
-      docsearch({
-        appId: '7ZBSP80X0K',
-        apiKey: '2a9d77b7d7b611725a62fd9ffb522880',
-        indexName: 'developers.taxjar.com',
-        inputSelector: '#docsearch-mobile'
-      });
     </script>
   </body>
 </html>

--- a/source/stylesheets/pages/_docs.scss
+++ b/source/stylesheets/pages/_docs.scss
@@ -7,6 +7,8 @@ body.integrations {
 
   .docs-sidebar {
     z-index: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
     position: fixed;
     top: 69px;
     left: 0;
@@ -77,7 +79,8 @@ body.integrations {
     }
 
     .docs-sidebar-footer {
-      position: absolute;
+      position: relative;
+      margin-top: 0px;
       bottom: 10px;
       padding: 10px 20px 10px 10px;
       font-size: 1.5rem;


### PR DESCRIPTION
While adding docsearch to the developer site in #22, we hid the overflow from `.docs-sidebar` so that the docsearch dropdown was entirely visible. On smaller screens, however, this disallows scrolling to view items at the bottom of the sidebar.

This PR adds logic to the styling as follows:

- When docsearch dropdown is shown, overflow is visible.
- When docsearch dropdown is hidden, overflow is auto/hidden.

Before (no scrolling):

![Before (no scrolling)2](https://user-images.githubusercontent.com/26824724/73471849-e196a100-433e-11ea-9a2d-0fdad8893801.gif)

After (scrolling):

![After (scrolling)2](https://user-images.githubusercontent.com/26824724/73471887-f07d5380-433e-11ea-8b2f-bc4875fb3d08.gif)