### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.7.x
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.3.3'
+    - name: Build static website with Middleman and deploy to S3
+      env:
+        S3_ID: ${{ secrets.S3_ID }}
+        S3_SECRET: ${{ secrets.S3_SECRET }}
+        S3_BUCKET: ${{ secrets.S3_BUCKET }}
+        CF_DISTRIBUTION_ID: ${{ secrets.CF_DISTRIBUTION_ID }}
+      run: |
+        gem install bundler -v '~> 1.1'
+        bundle install
+        middleman build
+        s3_website push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         CF_DISTRIBUTION_ID: ${{ secrets.CF_DISTRIBUTION_ID }}
       run: |
         gem install bundler -v '~> 1.1'
+        sudo npm install -g bower
         bundle install
+        bower install
         middleman build
         s3_website push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7.x
+    - name: Set up Ruby 2.3.3
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.3.3'


### PR DESCRIPTION
The Codeship app sometimes gets stuck, causing PRs to be unmergeable without Owner rights.

This PR moves to GitHub Actions for our release flow. The developers site will be built and deployed whenever a push to the 'master' branch occurs.