### PR TITLE
Update API sign-up links

### DIFF
--- a/source/blog/2017-05-18-handling-sales-tax-with-laravel-cashier.md
+++ b/source/blog/2017-05-18-handling-sales-tax-with-laravel-cashier.md
@@ -24,7 +24,7 @@ composer require taxjar/taxjar-php
 
 ### TaxJar API Token
 
-You’ll also need a way to authenticate with our sales tax API to request rates. [Sign up for a TaxJar account](https://app.taxjar.com/api_sign_up/basic/) to generate a new API token. From there, copy and paste the API token into your project’s `.env` file:
+You’ll also need a way to authenticate with our sales tax API to request rates. [Sign up for a TaxJar account](https://app.taxjar.com/api_sign_up/) to generate a new API token. From there, copy and paste the API token into your project’s `.env` file:
 
 ```
 TAXJAR_API_TOKEN=[Your API Token]

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -46,7 +46,7 @@
             <nav>
               <ul>
                 <li><a href="https://app.taxjar.com/sign_in/" class="btn">Log In</a></li>
-                <li><a href="https://app.taxjar.com/api_sign_up/basic/" class="btn cta">Get API Token</a></li>
+                <li><a href="https://app.taxjar.com/api_sign_up/" class="btn cta">Get API Token</a></li>
               </ul>
               <ul class="navbar-responsive">
                 <li><a href="#" class="btn navbar-toggle">Menu</a></li>

--- a/source/partials/_sidebar.erb
+++ b/source/partials/_sidebar.erb
@@ -1,5 +1,5 @@
 <div class="sidebar__cta">
-  <a href="https://app.taxjar.com/api_sign_up/basic/" class="btn cta trial-link">Get API Token</a>
+  <a href="https://app.taxjar.com/api_sign_up/" class="btn cta trial-link">Get API Token</a>
   <a href="https://app.taxjar.com" class="btn"><b>Log In</b></a>
 </div><br>
 


### PR DESCRIPTION
The API sign-up link has changed to [`app.taxjar.com/api_sign_up`](https://app.taxjar.com/api_sign_up).